### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='MolScribe',
       setup_requires=['numpy'],
       install_requires=[
         "numpy",
-        "torch>=1.11.0,<2.0",
+        "torch>=1.11.0",
         "pandas",
         "matplotlib",
         "opencv-python>=4.5.5.64",


### PR DESCRIPTION
Remove the upper torch dependency restriction.

As of now, one of the dependecies timm 0.4.12 requires torchvision.
Both available torchvision version (0.15.1 and 0.15.2) require torch above 2.0

This creates a dependency clash where molscribe requires torch<2.0 and torchivision requires torch==2.0.1

The current version of Molscribe works with torch==2.0.1