### PR TITLE
skip unreasonable number of elements

### DIFF
--- a/molscribe/chemistry.py
+++ b/molscribe/chemistry.py
@@ -204,6 +204,8 @@ def _expand_carbon(elements: list):
         # expand carbon sequence
         if elt == 'C' and num > 1 and i + 1 < len(elements):
             next_elt, next_num = elements[i + 1]
+            if next_num > 100000:
+                i += 1; continue
             quotient, remainder = next_num // num, next_num % num
             for _ in range(num):
                 expanded.append('C')


### PR DESCRIPTION
this is related to a previous PR that was merged. When next element is showing an unreasonable number of elements it also needs to be skipped. 

Eample offending image from USPTO attached.

[US20210002232A1-20210107-C00026.TIF.zip](https://github.com/user-attachments/files/18364007/US20210002232A1-20210107-C00026.TIF.zip)


@thomas0809 