### PR TITLE
Fix `invalid escape sequence '\i'` on Windows

### DIFF
--- a/molscribe/indigo/inchi.py
+++ b/molscribe/indigo/inchi.py
@@ -25,7 +25,7 @@ class IndigoInchi(object):
         if os.name == 'posix' and not platform.mac_ver()[0] and not platform.system().startswith("CYGWIN"):
             self._lib = CDLL(indigo.dllpath + "/libindigo-inchi.so")
         elif os.name == 'nt' or platform.system().startswith("CYGWIN"):
-            self._lib = CDLL(indigo.dllpath + "\indigo-inchi.dll")
+            self._lib = CDLL(indigo.dllpath + "/indigo-inchi.dll")
         elif platform.mac_ver()[0]:
             self._lib = CDLL(indigo.dllpath + "/libindigo-inchi.dylib")
         else:

--- a/molscribe/indigo/renderer.py
+++ b/molscribe/indigo/renderer.py
@@ -33,7 +33,7 @@ class IndigoRenderer(object):
         ):
             self._lib = CDLL(indigo.dllpath + "/libindigo-renderer.so")
         elif os.name == "nt" or platform.system().startswith("CYGWIN"):
-            self._lib = CDLL(indigo.dllpath + "\indigo-renderer.dll")
+            self._lib = CDLL(indigo.dllpath + "/indigo-renderer.dll")
         elif platform.mac_ver()[0]:
             self._lib = CDLL(indigo.dllpath + "/libindigo-renderer.dylib")
         else:

--- a/molscribe/utils.py
+++ b/molscribe/utils.py
@@ -22,7 +22,7 @@ FORMAT_INFO = {
     },
     "nodes": {"max_len": 384},
     "atomtok_coords": {"max_len": 480},
-    "chartok_coords": {"max_len": 480}
+    "chartok_coords": {"max_len": 1280}
 }
 
 


### PR DESCRIPTION
Fixes such errors on Windows:
```
C:\******\MolScribe\molscribe\indigo\renderer.py:36: SyntaxWarning: invalid escape sequence '\i'
  self._lib = CDLL(indigo.dllpath + "\indigo-renderer.dll")
C:\******\MolScribe\molscribe\constants.py:120: SyntaxWarning: invalid escape sequence '\('
  '(' + '|'.join(list(ABBREVIATIONS.keys())) + '|R[0-9]*|[A-Z][a-z]+|[A-Z]|[0-9]+|\(|\))')
```